### PR TITLE
Crash due to EqualizeDocumentLength() sometimes result in unequal lengths

### DIFF
--- a/ClangFormatEditor/DiffStyle/DiffMatchPatchWrapper.cs
+++ b/ClangFormatEditor/DiffStyle/DiffMatchPatchWrapper.cs
@@ -346,6 +346,15 @@ namespace ClangFormatEditor
             break;
         }
       }
+      
+      if(lines.Count < emptyLinesToAdd)
+      {
+        for (int i = lines.Count; i <= Math.Abs(emptyLinesToAdd); i++)
+        {
+          lines.Add(Environment.NewLine);
+        }
+      }
+
       return lines;
     }
 


### PR DESCRIPTION
 #23  #29